### PR TITLE
Create english version of the current german RC text

### DIFF
--- a/docs/00b-basics/01-what-to-expect-of-this-module.adoc
+++ b/docs/00b-basics/01-what-to-expect-of-this-module.adoc
@@ -8,11 +8,18 @@ Das Modul betrachtet die verschiedenen Arten, wie APIs Wert erzeugen: Als techni
 Im Rahmen dieses Moduls sprechen wir bei APIs immer von Netzwerk-basierten Schnittstellen, also nicht von lokalen Programmierschnittstellen.
 
 Neben dem Schwerpunkt auf technischem Themen werden auch strategische Aspekte behandelt wie die Wertschöpfung und die Verwendungen von APIs als Team-Kollaboration im Unternehmen. Damit eignet sich das Modul gut, um sich dem Thema APIs mit einer weiteren Perspektive als dem rein technischen Blick zu nähern.
+
 // end::DE[]
 
 // tag::EN[]
 === What does the module “{curriculum-short}” convey?
 
-The module presents {curriculum-short} to the participants …
-At the end of the module, the participants know … and are able to …
+Application Programming Interfaces, or APIs, enable the use of digital services via programmable interfaces. Their use has increased significantly over the last 20 years. From a software architecture perspective, APIs are relevant from both a producer and consumer point of view: Software components should ideally be understood as reusable products; APIs help to make a software component easily reusable. Today, more and more services are available via APIs. As a consumer of these services, it is easier to concentrate on core tasks and outsource other tasks to external components.
+
+The module looks at the different ways in which APIs create value: as technical interfaces that allow different components to communicate with each other; as organisational interfaces that allow different teams to develop their respective components with fewer interdependencies; and as business-oriented building blocks that allow the organisation to develop new services faster and more effectively.
+
+In this module, we always refer to APIs as network-based interfaces, i.e. not as local programming interfaces.
+
+In addition to the focus on technical topics, strategic aspects such as value creation and the use of APIs as team collaboration in the company are also covered. The module is therefore well suited to approaching the topic of APIs from a broader perspective than a purely technical one.
+
 // end::EN[]

--- a/docs/00b-basics/02-curriculum-structure-and-chronological-breakdown.adoc
+++ b/docs/00b-basics/02-curriculum-structure-and-chronological-breakdown.adoc
@@ -44,8 +44,8 @@
 |
 
 | Summe
-| 600 (10 h)
-| 240 (4 h)
+| 540 (9 h)
+| 180 (3 h)
 |===
 
 // end::DE[]
@@ -53,18 +53,51 @@
 // tag::EN[]
 === Curriculum Structure and Recommended Durations
 
-[cols="<,>", options="header"]
+[cols="<,>,>", options="header"]
 |===
 | Content
 | Recommended minimum duration (minutes)
-| 1. Introduction | 180
-| 2. xz | 150
-| 3. Lots of theory | 120
-| 4. xy and example | 180
-| 5. abc und d | 210
-| 6. Final example | 120
-| |
-| Total | 960 (16h)
+| Übungszeit (Minuten)
+
+| 1. Why APIs are Important
+| 60
+| 0
+
+| 2. How APIs are Creating Value
+| 60
+| 30
+
+| 3. API Styles and Technologies
+| 60
+| 30
+
+| 4. API Design
+| 90
+| 30
+
+| 5. Description of APIs
+| 90
+| 30
+
+| 6. API Lifecycle and API Tooling
+| 60
+| 30
+
+| 7. API Security
+| 60
+| 30
+
+| 8. APIs at Scale: Platforms and Governance
+| 60
+| 0
+
+|
+|
+|
+
+| Total
+| 540 (9 h)
+| 180 (3 h)
 
 |===
 

--- a/docs/00b-basics/04-prerequisites-for-this-training.adoc
+++ b/docs/00b-basics/04-prerequisites-for-this-training.adoc
@@ -2,25 +2,20 @@
 === Voraussetzungen
 
 Teilnehmerinnen und Teilnehmer **sollten** folgende Kenntnisse und/oder Erfahrung mitbringen:
+
 - Architekten
 - Entwickler
 - andere technisch orientierte Personen, die sich einen umfassenden Überblick über das Thema APIs verschaffen möchten.
+
 // end::DE[]
 
 // tag::EN[]
 === Prerequisites
 
-Participants **should** have the following prerequisite knowledge:
+Participants **should** have the following knowledge and/or experience:
 
-- Prerequisite 1
-- Prerequisite 2, etc.
+- Architects
+- Developers
+- other technically orientated people who would like to gain a comprehensive overview of the topic of APIs.
 
-Knowledge in the following areas may be **helpful** for understanding some concepts:
-
-- Area 1:
-  * Knowledge 1
-  * Experience 2
-  * Knowledge 3
-  * Experience 4
-  * Understanding 5
 // end::EN[]

--- a/docs/01-why-apis/00-structure.adoc
+++ b/docs/01-why-apis/00-structure.adoc
@@ -8,7 +8,7 @@
 // end::DE[]
 
 // tag::EN[]
-== Why APIs are important
+== Why APIs are Important
 // end::EN[]
 
 

--- a/docs/01-why-apis/01-duration-terms.adoc
+++ b/docs/01-why-apis/01-duration-terms.adoc
@@ -15,4 +15,5 @@ Lokale APIs, Netzwerk-basierte APIs, API Landschaft, Systemintegration
 
 === Terms and Principles
 Local APIs, Network-Based APIs, API landscape, Systems Integration
+
 // end::EN[]

--- a/docs/01-why-apis/01-duration-terms.adoc
+++ b/docs/01-why-apis/01-duration-terms.adoc
@@ -10,9 +10,9 @@ Lokale APIs, Netzwerk-basierte APIs, API Landschaft, Systemintegration
 
 // tag::EN[]
 |===
-| Duration: XXX min | Practice time: XXX min
+| Duration: 60 min | Practice time: 0 min
 |===
 
 === Terms and Principles
-Term 1, Term 2, Term 3
+Local APIs, Network-Based APIs, API landscape, Systems Integration
 // end::EN[]

--- a/docs/01-why-apis/02-learning-goals.adoc
+++ b/docs/01-why-apis/02-learning-goals.adoc
@@ -29,7 +29,7 @@ They understand the development from local APIs to network-based APIs and the cu
 [[LG-1-2]]
 ==== LG 1-2: Comparing different Styles and Concepts of Integration
 
-Different approaches for systems integration are kow to participants and can be compared and contrasted, specifically:
+Different approaches for systems integration are known to participants and can be compared and contrasted, specifically:
 
 * Integration through a shared database
 * File-based systems integration

--- a/docs/01-why-apis/02-learning-goals.adoc
+++ b/docs/01-why-apis/02-learning-goals.adoc
@@ -21,6 +21,19 @@ Unterschiedliche Ansätze zur Systemintegration sind den Teilnehmer:innen bekann
 
 // tag::EN[]
 [[LG-1-1]]
-==== LG 1-1: The is the first learning goal, in category xy
-tbd.
+==== LG 1-1: Understanding APIs in the Context of Software Development
+
+Participants understand APIs in the context of programming, computer networks, distributed systems, and software architecture.
+They understand the development from local APIs to network-based APIs and the current API landscape in the overall context.
+
+[[LG-1-2]]
+==== LG 1-2: Comparing different Styles and Concepts of Integration
+
+Different approaches for systems integration are kow to participants and can be compared and contrasted, specifically:
+
+* Integration through a shared database
+* File-based systems integration
+* Integration through synchronous communications, for example RPC (Remote Procedure Call)
+* Integration through asynchronous communications, for example message queues
+
 // end::EN[]

--- a/docs/01-why-apis/02-learning-goals.adoc
+++ b/docs/01-why-apis/02-learning-goals.adoc
@@ -21,13 +21,13 @@ Unterschiedliche Ansätze zur Systemintegration sind den Teilnehmer:innen bekann
 
 // tag::EN[]
 [[LG-1-1]]
-==== LG 1-1: Understanding APIs in the Context of Software Development
+==== LG 1-1: Understand APIs in the Context of Software Development
 
 Participants understand APIs in the context of programming, computer networks, distributed systems, and software architecture.
 They understand the development from local APIs to network-based APIs and the current API landscape in the overall context.
 
 [[LG-1-2]]
-==== LG 1-2: Comparing different Styles and Concepts of Integration
+==== LG 1-2: Compare different Styles and Concepts of Integration
 
 Different approaches for systems integration are known to participants and can be compared and contrasted, specifically:
 

--- a/docs/02-api-value/01-duration-terms.adoc
+++ b/docs/02-api-value/01-duration-terms.adoc
@@ -15,6 +15,6 @@ API Economy, API Wertschöpfung, API Business Models, Digitale Transformation
 |===
 
 === Terms and Principles
-Term 1, Term 2, Term 3
+API economy, API value creation, API business models, Digital Transformation
 
 // end::EN[]

--- a/docs/02-api-value/01-duration-terms.adoc
+++ b/docs/02-api-value/01-duration-terms.adoc
@@ -1,6 +1,6 @@
 // tag::DE[]
 |===
-| Dauer: 60 Min. | Übungszeit: 30 Min.
+| Dauer: 90 Min. | Übungszeit: 30 Min.
 |===
 
 === Begriffe und Konzepte
@@ -11,7 +11,7 @@ API Economy, API Wertschöpfung, API Business Models, Digitale Transformation
 
 // tag::EN[]
 |===
-| Duration: 60 min | Practice time: 30 min
+| Duration: 90 min | Practice time: 30 min
 |===
 
 === Terms and Principles

--- a/docs/02-api-value/02-learning-goals.adoc
+++ b/docs/02-api-value/02-learning-goals.adoc
@@ -31,12 +31,12 @@ Teilnehmer:innen können APIs einordnen in das grössere Bild digitaler Transfor
 
 // tag::EN[]
 [[LG-2-1]]
-==== LG 2-1: Understanding the "API Economy"
+==== LG 2-1: Understand the "API Economy"
 
 Participants understand the broader concept of the "API Economy" and understand how their products and activities fit into it.
 
 [[LG-2-2]]
-==== LG 2-2: Knowing Various Ways of API Value Creation
+==== LG 2-2: Know Various Ways of API Value Creation
 
 Participants know and understand the various ways in which APIs can help with value creation. On the top level, the different ways can be categorized into three areas:
 
@@ -47,12 +47,12 @@ Participants know and understand the various ways in which APIs can help with va
 Participants understand the various options inside these categories and the relationships between them. They also understand how a comprehensive API strategy adds value for all of these categories.
 
 [[LG-2-3]]
-==== LG 2-3: Understanding API Business Models
+==== LG 2-3: Understand API Business Models
 
 Participants have a detailed knowledge of the various business models for APIs and know a few specific examples. Starting from these different business models participants understand how to analyze existing business models and how they can be augmented with APIs.
 
 [[LG-2-4]]
-==== LG 2-4: Understanding APIs and Digital Transformation
+==== LG 2-4: Understand APIs and Digital Transformation
 
 Participants know how to fit APIs into the bigger picture of digital transformation. APIs are identified as necessary (but not sufficient) aspect of digital transformation, and other necessary aspects are known as well.
 

--- a/docs/02-api-value/02-learning-goals.adoc
+++ b/docs/02-api-value/02-learning-goals.adoc
@@ -30,7 +30,16 @@ Teilnehmer:innen können APIs einordnen in das grössere Bild digitaler Transfor
 // end::DE[]
 
 // tag::EN[]
-[[LG-1-1]]
-==== LG 1-1: The is the first learning goal, in category xy
-tbd.
+[[LG-2-1]]
+==== LG 2-1: Understanding the "API Economy"
+
+[[LG-2-2]]
+==== LG 2-2: Knowing Various Ways of API Value Creation
+
+[[LG-2-3]]
+==== LG 2-3: Understanding API Business Models
+
+[[LG-2-4]]
+==== LG 2-4: Understanding APIs and Digital Transformation
+
 // end::EN[]

--- a/docs/02-api-value/02-learning-goals.adoc
+++ b/docs/02-api-value/02-learning-goals.adoc
@@ -33,13 +33,27 @@ Teilnehmer:innen können APIs einordnen in das grössere Bild digitaler Transfor
 [[LG-2-1]]
 ==== LG 2-1: Understanding the "API Economy"
 
+Participants understand the broader concept of the "API Economy" and understand how their products and activities fit into it.
+
 [[LG-2-2]]
 ==== LG 2-2: Knowing Various Ways of API Value Creation
+
+Participants know and understand the various ways in which APIs can help with value creation. On the top level, the different ways can be categorized into three areas:
+
+* Private APIs which are used inside an organization
+* Partner APIs which are used with established partners
+* Public APIs which are offered as products to the general public
+
+Participants understand the various options inside these categories and the relationships between them. They also understand how a comprehensive API strategy adds value for all of these categories.
 
 [[LG-2-3]]
 ==== LG 2-3: Understanding API Business Models
 
+Participants have a detailed knowledge of the various business models for APIs and know a few specific examples. Starting from these different business models participants understand how to analyze existing business models and how they can be augmented with APIs.
+
 [[LG-2-4]]
 ==== LG 2-4: Understanding APIs and Digital Transformation
+
+Participants know how to fit APIs into the bigger picture of digital transformation. APIs are identified as necessary (but not sufficient) aspect of digital transformation, and other necessary aspects are known as well.
 
 // end::EN[]

--- a/docs/03-api-styles/01-duration-terms.adoc
+++ b/docs/03-api-styles/01-duration-terms.adoc
@@ -15,6 +15,6 @@ RPC, Ressource, Hypermedia, Query, Events, asynchrone Kommunikation, gRPC, HTTP 
 |===
 
 === Terms and Principles
-Term 1, Term 2, Term 3
+RPC, resource, hypermedia, query, events, asynchronous communications, gRPC, HTTP APIs, REST, GraphQL
 
 // end::EN[]

--- a/docs/03-api-styles/02-learning-goals.adoc
+++ b/docs/03-api-styles/02-learning-goals.adoc
@@ -31,10 +31,14 @@ Teilnehmer:innen erwerben ein Verständnis für Kriterien, wann welche Stile/Tec
 
 // tag::EN[]
 [[LG-3-1]]
-==== LG 3-1: TBD
+==== LG 3-1: Understanding Fundamental API Styles
 tbd.
 
 [[LG-3-2]]
-==== LG 3-2: TBD
+==== LG 3-2: Understanding Popular API Technologies and Associating Them With API Styles
+tbd.
+
+[[LG-3-3]]
+==== LG 3-3: Understanding When to Use Which Style and Technology and the Consequences of That Choice
 tbd.
 // end::EN[]

--- a/docs/03-api-styles/02-learning-goals.adoc
+++ b/docs/03-api-styles/02-learning-goals.adoc
@@ -4,7 +4,7 @@
 [[LZ-3-1]]
 ==== LZ 3-1: Grundlegende API-Stile verstehen
 
-Die folgenden API-Stile werden erläutert und ihre Vor- sowie Nachteile gegeneinander abgewogen:
+Die folgenden API-Stile werden verstanden und ihre Vor- sowie Nachteile können gegeneinander abgewogen werden:
 
 * RPC (Remote Procedure Call)
 * Resourcen-basiert

--- a/docs/03-api-styles/02-learning-goals.adoc
+++ b/docs/03-api-styles/02-learning-goals.adoc
@@ -15,7 +15,7 @@ Die folgenden API-Stile werden verstanden und ihre Vor- sowie Nachteile können 
 [[LZ-3-2]]
 ==== LZ 3-2: Populäre API-Technologien ein- und den jeweiligen API-Stilen zuordnen
 
-Teilnehmer:innen können die wichtigsten populären API-Technologien einordnen und kennen den von ihnen implementierten API-Stil, z. B.:
+Teilnehmer:innen können die wichtigsten populären API-Technologien einordnen und kennen den von ihnen implementierten API-Stil, z.B.:
 
 * gRPC
 * HTTP APIs
@@ -32,13 +32,28 @@ Teilnehmer:innen erwerben ein Verständnis für Kriterien, wann welche Stile/Tec
 // tag::EN[]
 [[LG-3-1]]
 ==== LG 3-1: Understanding Fundamental API Styles
-tbd.
+
+The following API styles are understood by participants and their advantages and drawbacks can be compared:
+
+* RPC (Remote Procedure Call)
+* Resource-based
+* Hypermedia
+* Query
+* Events & asynchronous communications
 
 [[LG-3-2]]
 ==== LG 3-2: Understanding Popular API Technologies and Associating Them With API Styles
-tbd.
+
+Participants are able to classify the most important API technologies and know which API style they are implementing, for example:
+
+* gRPC
+* HTTP APIs
+* REST
+* GraphQL
 
 [[LG-3-3]]
 ==== LG 3-3: Understanding When to Use Which Style and Technology and the Consequences of That Choice
-tbd.
+
+Participants gain knowledge of criteria when certain styles and technologies are a good or not-so-good fit, and which consequences the selection will have.
+
 // end::EN[]

--- a/docs/03-api-styles/02-learning-goals.adoc
+++ b/docs/03-api-styles/02-learning-goals.adoc
@@ -31,7 +31,7 @@ Teilnehmer:innen erwerben ein Verständnis für Kriterien, wann welche Stile/Tec
 
 // tag::EN[]
 [[LG-3-1]]
-==== LG 3-1: Understanding Fundamental API Styles
+==== LG 3-1: Understand Fundamental API Styles
 
 The following API styles are understood by participants and their advantages and drawbacks can be compared:
 
@@ -42,7 +42,7 @@ The following API styles are understood by participants and their advantages and
 * Events & asynchronous communications
 
 [[LG-3-2]]
-==== LG 3-2: Understanding Popular API Technologies and Associating Them With API Styles
+==== LG 3-2: Understand Popular API Technologies and Associating Them With API Styles
 
 Participants are able to classify the most important API technologies and know which API style they are implementing, for example:
 
@@ -52,7 +52,7 @@ Participants are able to classify the most important API technologies and know w
 * GraphQL
 
 [[LG-3-3]]
-==== LG 3-3: Understanding When to Use Which Style and Technology and the Consequences of That Choice
+==== LG 3-3: Understand When to Use Which Style and Technology and the Consequences of That Choice
 
 Participants gain knowledge of criteria when certain styles and technologies are a good or not-so-good fit, and which consequences the selection will have.
 

--- a/docs/04-api-design/01-duration-terms.adoc
+++ b/docs/04-api-design/01-duration-terms.adoc
@@ -14,5 +14,6 @@ Design von APIs, API First, konsumentengetriebenes API-Design, Postel's Law, For
 |===
 
 === Terms and Principles
-Term 1, Term 2, Term 3
+API design, API First, consumer-driven API design, Postel's Law, Forward and backward compatibility, Versioning and lifecycle of API products, JSON:API, API design style guides
+
 // end::EN[]

--- a/docs/04-api-design/01-duration-terms.adoc
+++ b/docs/04-api-design/01-duration-terms.adoc
@@ -4,7 +4,7 @@
 |===
 
 === Begriffe und Konzepte
-Design von APIs, API First, konsumentengetriebenes API-Design, Postel's Law, Forward und Backward Compatibility, Versionierung und Lebenszyklus von API Produkten, JSON:API, API Design Style Guides
+Design von APIs, API First, konsumentengetriebenes API-Design, Postel's Law, Forward und Backward Compatibility, Versionierung und Lebenszyklus von API Produkten, JSON:API, HAL, API Design Style Guides
 
 // end::DE[]
 
@@ -14,6 +14,6 @@ Design von APIs, API First, konsumentengetriebenes API-Design, Postel's Law, For
 |===
 
 === Terms and Principles
-API design, API First, consumer-driven API design, Postel's Law, Forward and backward compatibility, Versioning and lifecycle of API products, JSON:API, API design style guides
+API design, API First, consumer-driven API design, Postel's Law, Forward and backward compatibility, Versioning and lifecycle of API products, JSON:API, HAL, API design style guides
 
 // end::EN[]

--- a/docs/04-api-design/02-learning-goals.adoc
+++ b/docs/04-api-design/02-learning-goals.adoc
@@ -42,10 +42,26 @@ Hierzu zählen u. a.:
 
 // tag::EN[]
 [[LG-4-1]]
-==== LG 4-1: TBD
+==== LG 4-1: Understanding the Significance of API Design
 tbd.
 
 [[LG-4-2]]
-==== LG 4-2: TBD
+==== LG 4-2: Using the "outside-in" Approach for API Design
 tbd.
+[[LG-4-2]]
+==== LG 4-2: Using the "outside-in" Approach for API Design
+tbd.
+
+[[LG-4-3]]
+==== LG 4-3: Understanding Openness and Extensibility as Important Aspects for API Evolution
+tbd.
+
+[[LG-4-4]]
+==== LG 4-4: Understanding API Versioning
+tbd.
+
+[[LG-4-5]]
+==== LG 4-5: Understanding Good Practices for API Design
+tbd.
+
 // end::EN[]

--- a/docs/04-api-design/02-learning-goals.adoc
+++ b/docs/04-api-design/02-learning-goals.adoc
@@ -66,7 +66,11 @@ Participants also understand the consequences for API implementation in strong a
 [[LG-4-4]]
 ==== LG 4-4: Understanding API Versioning
 
-Participants gain knowledge for various aspects of versioning and how these are applied during the lifecycle of an API product.
+Participants gain knowledge for various aspects of versioning and how these are applied during the lifecycle of an API product. The following concepts are known:
+
+* Compatibility and the difference between forward and backward compatibility
+* Version identification in general and semantic versioning as a specific model for version identification
+* Different ways of version identification for APIs (for example, domain name, URI path, HTTP header, payload-based)
 
 [[LG-4-5]]
 ==== LG 4-5: Knowing Good Practices for API Design

--- a/docs/04-api-design/02-learning-goals.adoc
+++ b/docs/04-api-design/02-learning-goals.adoc
@@ -4,14 +4,14 @@
 [[LZ-4-1]]
 ==== LZ 4-1: Bedeutung von API Design verstehen
 
-Teilnehmer:innen verstehen, weshalb ein gewissenhaftes Design von API-Schnittstellen von großer Bedeutung ist und welchen Einfluss dies auf die Nutzbarkeit, Wartung, Weiterentwicklung und Verbreitung der Schnittstelle haben wird.
-
+Teilnehmer:innen verstehen, weshalb ein gewissenhaftes Design von API-Schnittstellen von großer Bedeutung ist und welchen Einfluss dies auf die Nutzbarkeit, Wartung, Weiterentwicklung und Verbreitung haben wird.
 
 [[LZ-4-2]]
 ==== LZ 4-2: API Design als "Outside-in" Ansatz anwenden
 
 Zu den wichtigsten Zielen von APIs zählt die effiziente Anbindung von Konsumenten an die Schnittstelle des Betreibers.
-Das Design sollte auf die Anforderungen der Konsumenten fokussiert sein und nicht entlang eventuell bestehender Systeme, Use Cases oder Datenbanken. Teilnehmer:innen kennen und verstehen die Ansätze von API First und konsumentengetriebenem API-Design.
+Das Design sollte auf die Anforderungen der Konsumenten fokussiert sein und nicht entlang eventuell bestehender Systeme, Use Cases oder Datenbanken.
+Teilnehmer:innen kennen und verstehen die Ansätze von API First und konsumentengetriebenem API-Design.
 
 [[LZ-4-3]]
 ==== LZ 4-3: Offenheit und Erweiterbarkeit als wichtige Aspekte für die Weiterentwicklung von APIs interpretieren
@@ -28,14 +28,13 @@ Teilnehmer:innen erlangen ein Verständnis für verschiedene Aspekte der Version
 ==== LZ 4-5: Good Practices für gelungenes API Design kennen
 
 Teilnehmer:innen lernen bewährte und verbreitete Ansätze für das Design von HTTP APIs kennen und verstehen die Vorteile und Herausforderungen.
-
-Hierzu zählen u. a.:
+Hierzu zählen u.a.:
 
 * URL-Pfade
 * korrekte Verwendung von HTTP-Methoden oder Operationen für häufig benötigte Funktionalität wie Suchen, Filtern oder Sortieren
-* Formatvorschläge wie JSON:API
+* Formatvorschläge wie JSON:API oder HAL
 * Problem Details for HTTP APIs (RFC 9457)
-* API Design Style Guides <<geewax>>
+* API Design Style Guides
 
 
 // end::DE[]
@@ -43,25 +42,38 @@ Hierzu zählen u. a.:
 // tag::EN[]
 [[LG-4-1]]
 ==== LG 4-1: Understanding the Significance of API Design
-tbd.
+
+Participants understand why careful API design is important and which influence it has on usability, maintenance, evolution, and adoption.
 
 [[LG-4-2]]
 ==== LG 4-2: Using the "outside-in" Approach for API Design
-tbd.
-[[LG-4-2]]
-==== LG 4-2: Using the "outside-in" Approach for API Design
-tbd.
+
+One of the most important goals of APIs is to efficiently connect consumers with the provider's interface.
+API design should be focused on the needs of the consumers.
+It shouldn't be based on existing systems, existing use cases, or databases.
+Participants know and understand the approaches of API First and consumer-oriented API design.
 
 [[LG-4-3]]
 ==== LG 4-3: Understanding Openness and Extensibility as Important Aspects for API Evolution
-tbd.
+
+Participants understand Postel's law, the concepts of forward and backward compatibility, and the importance of these concepts for the evolution of APIs.
+Participants also understand the consequences for API implementation in strong and statically typed languages.
 
 [[LG-4-4]]
 ==== LG 4-4: Understanding API Versioning
-tbd.
+
+Participants gain knowledge for various aspects of versioning and how these are applied during the lifecycle of an API product.
 
 [[LG-4-5]]
-==== LG 4-5: Understanding Good Practices for API Design
-tbd.
+==== LG 4-5: Knowing Good Practices for API Design
+
+Participants learn about established and widely used aspects for API design and understand their advantages and challenges.
+These aspects include:
+
+* URL paths
+* Using correct HTTP methods or operations for frequently needed functionality such as searching, filtering, or sorting
+* Proposed formats such as JSON:API or HAL
+* Problem Details for HTTP APIs (RFC 9457)
+* API Design Style Guides
 
 // end::EN[]

--- a/docs/04-api-design/02-learning-goals.adoc
+++ b/docs/04-api-design/02-learning-goals.adoc
@@ -45,12 +45,12 @@ Hierzu zählen u.a.:
 
 // tag::EN[]
 [[LG-4-1]]
-==== LG 4-1: Understanding the Significance of API Design
+==== LG 4-1: Understand the Significance of API Design
 
 Participants understand why careful API design is important and which influence it has on usability, maintenance, evolution, and adoption.
 
 [[LG-4-2]]
-==== LG 4-2: Using the "outside-in" Approach for API Design
+==== LG 4-2: Use the "outside-in" Approach for API Design
 
 One of the most important goals of APIs is to efficiently connect consumers with the provider's interface.
 API design should be focused on the needs of the consumers.
@@ -58,13 +58,13 @@ It shouldn't be based on existing systems, existing use cases, or databases.
 Participants know and understand the approaches of API First and consumer-oriented API design.
 
 [[LG-4-3]]
-==== LG 4-3: Understanding Openness and Extensibility as Important Aspects for API Evolution
+==== LG 4-3: Understand Openness and Extensibility as Important Aspects for API Evolution
 
 Participants understand Postel's law, the concepts of forward and backward compatibility, and the importance of these concepts for the evolution of APIs.
 Participants also understand the consequences for API implementation in strong and statically typed languages.
 
 [[LG-4-4]]
-==== LG 4-4: Understanding API Versioning
+==== LG 4-4: Understand API Versioning
 
 Participants gain knowledge for various aspects of versioning and how these are applied during the lifecycle of an API product. The following concepts are known:
 
@@ -73,7 +73,7 @@ Participants gain knowledge for various aspects of versioning and how these are 
 * Different ways of version identification for APIs (for example, domain name, URI path, HTTP header, payload-based)
 
 [[LG-4-5]]
-==== LG 4-5: Knowing Good Practices for API Design
+==== LG 4-5: Know Good Practices for API Design
 
 Participants learn about established and widely used aspects for API design and understand their advantages and challenges.
 These aspects include:

--- a/docs/05-api-description/01-duration-terms.adoc
+++ b/docs/05-api-description/01-duration-terms.adoc
@@ -4,7 +4,7 @@
 |===
 
 === Begriffe und Konzepte
-API-Beschreibung, OpenAPI, protocol buffers, AsyncAPI, GraphQL
+API-Beschreibung, OpenAPI, Protocol Buffers, AsyncAPI, GraphQL
 
 // end::DE[]
 
@@ -14,6 +14,6 @@ API-Beschreibung, OpenAPI, protocol buffers, AsyncAPI, GraphQL
 |===
 
 === Terms and Principles
-API description, OpenAPI, protocol buffers, AsyncAPI, GraphQL
+API description, OpenAPI, Protocol Buffers, AsyncAPI, GraphQL
 
 // end::EN[]

--- a/docs/05-api-description/01-duration-terms.adoc
+++ b/docs/05-api-description/01-duration-terms.adoc
@@ -4,7 +4,7 @@
 |===
 
 === Begriffe und Konzepte
-API-Beschreibung, OpenAPI
+API-Beschreibung, OpenAPI, protocol buffers, AsyncAPI, GraphQL
 
 // end::DE[]
 
@@ -14,6 +14,6 @@ API-Beschreibung, OpenAPI
 |===
 
 === Terms and Principles
-Term 1, Term 2, Term 3
+API description, OpenAPI, protocol buffers, AsyncAPI, GraphQL
 
 // end::EN[]

--- a/docs/05-api-description/02-learning-goals.adoc
+++ b/docs/05-api-description/02-learning-goals.adoc
@@ -38,17 +38,17 @@ OpenAPI ist spezialisiert auf HTTP APIs. Für andere API-Stile können alternati
 
 // tag::EN[]
 [[LG-5-1]]
-==== LG 5-1: Understanding the Significance of API Descriptions
+==== LG 5-1: Understand the Significance of API Descriptions
 
 Participants understand the value of API descriptions and understand the various stakeholders. The problem of "API Drift" is known. Participants understand the relationship between design, implementation, versioning, description, and description versioning, and they understand how these concepts relate ideally and in real-world scenarios.
 
 [[LG-5-2]]
-==== LG 5-2: Understanding OpenAPI as a Description Language for HTTP APIs
+==== LG 5-2: Understand OpenAPI as a Description Language for HTTP APIs
 
 Participants understand OpenAPI as a description language that is specialized for HTTP-based APIs. They understand the history of OpenAPI and how the various versions evolved. Participants understand how to use OpenAPI for code generation both on the provider side and on the consumer side. The overall structure of JSON and YAML is understood.
 
 [[LG-5-3]]
-==== LG 5-3: Understanding OpenAPI's Structure
+==== LG 5-3: Understand OpenAPI's Structure
 
 Participants understand the main elements of an OpenAPI description and how to use these for describing concrete APIs.
 
@@ -58,7 +58,7 @@ Participants understand the main elements of an OpenAPI description and how to u
 * Mechanisms such as Tags, Security, Components, and Webhooks
 
 [[LG-5-4]]
-==== LG 5-4: Understanding Alternative Description Languages
+==== LG 5-4: Understand Alternative Description Languages
 
 OpenAPI is specialized for HTTP-based APIs. For other API styles, it is possible to use alternative descriptions languages that have the same general goals. Participants know these alternative description languages and can associate them with API styles.
 

--- a/docs/05-api-description/02-learning-goals.adoc
+++ b/docs/05-api-description/02-learning-goals.adoc
@@ -19,8 +19,8 @@ Die generellen Strukturen von JSON und YAML sind bekannt.
 
 Teilnehmer:innen verstehen die Hauptelemente einer OpenAPI Beschreibung und wie diese für konkrete APIs verwendet werden.
 
-* Resourcen (Paths)
-* Interaktionen
+* Ressourcen (Paths)
+* Interaktionen (Operations)
 * Repräsentationen
 * Mechanismen wie Tags, Security, Components und Webhooks
 
@@ -34,18 +34,27 @@ OpenAPI ist spezialisiert auf HTTP APIs. Für andere API-Stile können alternati
 // tag::EN[]
 [[LG-5-1]]
 ==== LG 5-1: Understanding the Significance of API Descriptions
-tbd.
+
+Participants understand the value of API descriptions and understand the various stakeholders. The problem of "API Drift" is known. Participants understand the relationship between design, implementation, versioning, description, and description versioning, and they understand how these concepts relate ideally and in real-world scenarios.
 
 [[LG-5-2]]
 ==== LG 5-2: Understanding OpenAPI as a Description Language for HTTP APIs
-tbd.
+
+Participants understand OpenAPI as a description language that is specialized for HTTP-based APIs. They understand the history of OpenAPI and how the various versions evolved. Participants understand how to use OpenAPI for code generation both on the provider side and on the consumer side. The overall structure of JSON and YAML is understood.
 
 [[LG-5-3]]
 ==== LG 5-3: Understanding OpenAPI's Structure
-tbd.
+
+Participants understand the main elements of an OpenAPI description and how to use these for describing concrete APIs.
+
+* Resourcen (Paths)
+* Interactions (Operations)
+* Representations
+* Mechanisms such as Tags, Security, Components, and Webhooks
 
 [[LG-5-4]]
 ==== LG 5-4: Understanding Alternative Description Languages
-tbd.
+
+OpenAPI is specialized for HTTP-based APIs. For other API styles, it is possible to use alternative descriptions languages that have the same general goals. Participants know these alternative description languages and can associate them with API styles.
 
 // end::EN[]

--- a/docs/05-api-description/02-learning-goals.adoc
+++ b/docs/05-api-description/02-learning-goals.adoc
@@ -47,7 +47,7 @@ Participants understand OpenAPI as a description language that is specialized fo
 
 Participants understand the main elements of an OpenAPI description and how to use these for describing concrete APIs.
 
-* Resourcen (Paths)
+* Resources (Paths)
 * Interactions (Operations)
 * Representations
 * Mechanisms such as Tags, Security, Components, and Webhooks

--- a/docs/05-api-description/02-learning-goals.adoc
+++ b/docs/05-api-description/02-learning-goals.adoc
@@ -33,10 +33,19 @@ OpenAPI ist spezialisiert auf HTTP APIs. Für andere API-Stile können alternati
 
 // tag::EN[]
 [[LG-5-1]]
-==== LG 5-1: TBD
+==== LG 5-1: Understanding the Significance of API Descriptions
 tbd.
 
 [[LG-5-2]]
-==== LG 5-2: TBD
+==== LG 5-2: Understanding OpenAPI as a Description Language for HTTP APIs
 tbd.
+
+[[LG-5-3]]
+==== LG 5-3: Understanding OpenAPI's Structure
+tbd.
+
+[[LG-5-4]]
+==== LG 5-4: Understanding Alternative Description Languages
+tbd.
+
 // end::EN[]

--- a/docs/06-api-lifecycle/01-duration-terms.adoc
+++ b/docs/06-api-lifecycle/01-duration-terms.adoc
@@ -1,6 +1,6 @@
 // tag::DE[]
 |===
-| Dauer: 60 Min. | Übungszeit: 30 Min.
+| Dauer: 90 Min. | Übungszeit: 60 Min.
 |===
 
 === Begriffe und Konzepte
@@ -11,7 +11,7 @@ API Lifecycle, API Produkt, Linting, Contract Testing, API Gateway
 
 // tag::EN[]
 |===
-| Duration: 60 min | Practice time: 30 min
+| Duration: 90 min | Practice time: 60 min
 |===
 
 === Terms and Principles

--- a/docs/06-api-lifecycle/01-duration-terms.adoc
+++ b/docs/06-api-lifecycle/01-duration-terms.adoc
@@ -15,6 +15,7 @@ API Lifecycle, API Produkt, Linting, Contract Testing, API Gateway
 |===
 
 === Terms and Principles
-Term 1, Term 2, Term 3
+
+API lifecycle, API product, linting, contract testing, API gateway
 
 // end::EN[]

--- a/docs/06-api-lifecycle/02-learning-goals.adoc
+++ b/docs/06-api-lifecycle/02-learning-goals.adoc
@@ -25,14 +25,14 @@ Teilnehmer:innen können mit einigen dieser Tools praktisch arbeiten und versteh
 
 // tag::EN[]
 [[LG-6-1]]
-==== LG 6-1: Understanding the API Lifecycle
+==== LG 6-1: Understand the API Lifecycle
 
 Participants understand the various stages of the development cycle of an API product and the typical tasks that are performed throughout these stages.
 Participants understand the the various stages of planning, requirements analysis, design, prototyping, development, testing, quality assurance, deployment, publication, operations, and maintenance, and how to improve an API product in an iterative way.
 Participants also now the different lifecycle stages of an API such as prototype, production, deprecation, and sunsetting.
 
 [[LG-6-2]]
-==== LG 6-2: Managing APIs as Products
+==== LG 6-2: Manage APIs as Products
 
 APIs are often used in loosely coupled scenarios and for this reason it makes sense to manage them as products.
 Participants understand what it means to manage an API as a product.

--- a/docs/06-api-lifecycle/02-learning-goals.adoc
+++ b/docs/06-api-lifecycle/02-learning-goals.adoc
@@ -28,7 +28,7 @@ Teilnehmer:innen können mit einigen dieser Tools praktisch arbeiten und versteh
 ==== LG 6-1: Understand the API Lifecycle
 
 Participants understand the various stages of the development cycle of an API product and the typical tasks that are performed throughout these stages.
-Participants understand the the various stages of planning, requirements analysis, design, prototyping, development, testing, quality assurance, deployment, publication, operations, and maintenance, and how to improve an API product in an iterative way.
+Participants understand the various stages of planning, requirements analysis, design, prototyping, development, testing, quality assurance, deployment, publication, operations, and maintenance, and how to improve an API product in an iterative way.
 Participants also now the different lifecycle stages of an API such as prototype, production, deprecation, and sunsetting.
 
 [[LG-6-2]]

--- a/docs/06-api-lifecycle/02-learning-goals.adoc
+++ b/docs/06-api-lifecycle/02-learning-goals.adoc
@@ -26,14 +26,22 @@ Teilnehmer:innen können mit einigen dieser Tools praktisch arbeiten und versteh
 // tag::EN[]
 [[LG-6-1]]
 ==== LG 6-1: Understanding the API Lifecycle
-tbd.
+
+Participants understand the various stages of the development cycle of an API product and the typical tasks that are performed throughout these stages.
+Participants understand the the various stages of planning, requirements analysis, design, prototyping, development, testing, quality assurance, deployment, publication, operations, and maintenance, and how to improve an API product in an iterative way.
+Participants also now the different lifecycle stages of an API such as prototype, production, deprecation, and sunsetting.
 
 [[LG-6-2]]
 ==== LG 6-2: Managing APIs as Products
-tbd.
+
+APIs are often used in loosely coupled scenarios and for this reason it makes sense to manage them as products.
+Participants understand what it means to manage an API as a product.
+API product management starts with focus on a set of consumers, deals with questions of usability, includes feedback, and also handles questions of deprecation and how to provide alternatives.
 
 [[LG-6-3]]
 ==== LG 6-3: Know API Lifecycle Tooling
-tbd.
+
+Participants know typical tools that are used throughout the API lifecycle. These tools support producers as well as consumers and include functionality such as linting, testing (e.g., contract testing), and mocking and operations (API gateways).
+Participants gain some practical knowledge of some of these tools and understand how the fit into the bigger picture of API lifecycle tooling.
 
 // end::EN[]

--- a/docs/06-api-lifecycle/02-learning-goals.adoc
+++ b/docs/06-api-lifecycle/02-learning-goals.adoc
@@ -25,10 +25,15 @@ Teilnehmer:innen können mit einigen dieser Tools praktisch arbeiten und versteh
 
 // tag::EN[]
 [[LG-6-1]]
-==== LG 6-1: TBD
+==== LG 6-1: Understanding the API Lifecycle
 tbd.
 
 [[LG-6-2]]
-==== LG 6-2: TBD
+==== LG 6-2: Managing APIs as Products
 tbd.
+
+[[LG-6-3]]
+==== LG 6-3: Know API Lifecycle Tooling
+tbd.
+
 // end::EN[]

--- a/docs/06-api-lifecycle/02-learning-goals.adoc
+++ b/docs/06-api-lifecycle/02-learning-goals.adoc
@@ -41,7 +41,7 @@ API product management starts with focus on a set of consumers, deals with quest
 [[LG-6-3]]
 ==== LG 6-3: Know API Lifecycle Tooling
 
-Participants know typical tools that are used throughout the API lifecycle. These tools support producers as well as consumers and include functionality such as linting, testing (e.g., contract testing), and mocking and operations (API gateways).
-Participants gain some practical knowledge of some of these tools and understand how the fit into the bigger picture of API lifecycle tooling.
+Participants know typical tools that are used throughout the API lifecycle. These tools support producers as well as consumers and include functionality such as linting, testing (e.g., contract testing) and mocking, and operations (API gateways).
+Participants gain practical knowledge of some of these tools and understand how they fit into the bigger picture of API lifecycle tooling.
 
 // end::EN[]

--- a/docs/07-api-security/02-learning-goals.adoc
+++ b/docs/07-api-security/02-learning-goals.adoc
@@ -17,10 +17,13 @@ Teilnehmer:innen verstehen, wie HTTPS, HTTP-Authentisierung, OAuth und OpenID Co
 // tag::EN[]
 [[LG-7-2]]
 ==== LG 7-2: Understanding Communications Security Fundamentals
-tbd.
+
+Participants understand the foundations of communications security and are able to relate them to technologies such as TCP, HTTP, and TLS.
+Participants understand the relevance of secure communications, even in the case of internal interfaces.
 
 [[LG-7-2]]
 ==== LG 7-2: Understanding Security Technologies for APIs
-tbd.
+
+Participants understand how HTTPS, HTTP authentication, OAuth, and OpenID Connect, how they relate and differ, and how these technologies heklp when it comes to securing APIs.
 
 // end::EN[]

--- a/docs/07-api-security/02-learning-goals.adoc
+++ b/docs/07-api-security/02-learning-goals.adoc
@@ -24,6 +24,6 @@ Participants understand the relevance of secure communications, even in the case
 [[LG-7-2]]
 ==== LG 7-2: Understanding Security Technologies for APIs
 
-Participants understand how HTTPS, HTTP authentication, OAuth, and OpenID Connect, how they relate and differ, and how these technologies heklp when it comes to securing APIs.
+Participants understand HTTPS, HTTP authentication, OAuth, and OpenID Connect, how they relate and differ, and how these technologies help when it comes to securing APIs.
 
 // end::EN[]

--- a/docs/07-api-security/02-learning-goals.adoc
+++ b/docs/07-api-security/02-learning-goals.adoc
@@ -16,10 +16,11 @@ Teilnehmer:innen verstehen, wie HTTPS, HTTP-Authentisierung, OAuth und OpenID Co
 
 // tag::EN[]
 [[LG-7-2]]
-==== LG 7-2: TBD
+==== LG 7-2: Understanding Communications Security Fundamentals
 tbd.
 
 [[LG-7-2]]
-==== LG 7-2: TBD
+==== LG 7-2: Understanding Security Technologies for APIs
 tbd.
+
 // end::EN[]

--- a/docs/07-api-security/02-learning-goals.adoc
+++ b/docs/07-api-security/02-learning-goals.adoc
@@ -16,13 +16,13 @@ Teilnehmer:innen verstehen, wie HTTPS, HTTP-Authentisierung, OAuth und OpenID Co
 
 // tag::EN[]
 [[LG-7-2]]
-==== LG 7-2: Understanding Communications Security Fundamentals
+==== LG 7-2: Understand Communications Security Fundamentals
 
 Participants understand the foundations of communications security and are able to relate them to technologies such as TCP, HTTP, and TLS.
 Participants understand the relevance of secure communications, even in the case of internal interfaces.
 
 [[LG-7-2]]
-==== LG 7-2: Understanding Security Technologies for APIs
+==== LG 7-2: Understand Security Technologies for APIs
 
 Participants understand HTTPS, HTTP authentication, OAuth, and OpenID Connect, how they relate and differ, and how these technologies help when it comes to securing APIs.
 

--- a/docs/08-api-governance/01-duration-terms.adoc
+++ b/docs/08-api-governance/01-duration-terms.adoc
@@ -15,6 +15,7 @@ Internal Developer Platform (IDP), API Plattform, Business Plattform, API Guidel
 |===
 
 === Terms and Principles
-Term 1, Term 2, Term 3
+
+Internal developer platform (IDP), API platform, business platform, API guidelines, API design platform, self service
 
 // end::EN[]

--- a/docs/08-api-governance/01-duration-terms.adoc
+++ b/docs/08-api-governance/01-duration-terms.adoc
@@ -1,6 +1,6 @@
 // tag::DE[]
 |===
-| Dauer: 60 Min. | Übungszeit: 0 Min.
+| Dauer: 60 Min. | Übungszeit: 30 Min.
 |===
 
 === Begriffe und Konzepte
@@ -11,7 +11,7 @@ Internal Developer Platform (IDP), API Plattform, Business Plattform, API Guidel
 
 // tag::EN[]
 |===
-| Duration: 60 min | Practice time: 0 min
+| Duration: 60 min | Practice time: 30 min
 |===
 
 === Terms and Principles

--- a/docs/08-api-governance/02-learning-goals.adoc
+++ b/docs/08-api-governance/02-learning-goals.adoc
@@ -40,7 +40,7 @@ Dies sind der Konsum von Diensten (X-a-a-S Modell) sowie das Anbieten von Dienst
 [[LG-8-1]]
 ==== LG 8-1: Comparing Various Notions of Platform
 
-Participants understand the various areas in which the notion of platforms are being used. They understand how these notions different and how they complement each other.
+Participants understand the various areas in which the notion of platforms are being used. They understand how these notions are different and how they complement each other.
 
 * Internal developer platform (IDP)
 * API platform
@@ -51,16 +51,16 @@ Participants know how to differentiate between the mostly inward focus of an IDP
 [[LG-8-2]]
 ==== LG 8-2: Understanding API Guidelines
 
-Participants understand the motivation for API guidelines. They understand the goals of creating harmonized practices for both API design and the implementation practices for APIs. Tools for supporting API guidelines such as linting are know and participants understand how they work.
+Participants understand the motivation for API guidelines. They understand the goals of creating harmonized practices for both API design and the implementation practices for APIs. Tools for supporting API guidelines such as linting are known and participants understand how they work.
 
 [[LG-8-3]]
 ==== LG 8-3: Establishing and Managing API Guidelines
 
-Participants know some well-known examples of API guidelines by specific organizations. They also know good practices for managing and evolving API guidelines. Participants understand API guidelines as a living document that managed in participatory ways which document actual practices (as opposed to describing an aspirational goal state).
+Participants know some well-known examples of API guidelines by specific organizations. They also know good practices for managing and evolving API guidelines. Participants understand API guidelines as a living document that is managed in participatory ways which document actual practices (as opposed to describing an aspirational goal state).
 
 [[LG-8-4]]
 ==== LG 8-4: Using APIs as Team Interfaces
 
-Participants know Team Topologies as an organizational model for making team work more effective. The specific focus is on understanding how APIs are necessary to make the Team Topologies model work. These areas are the consumption of existing services (X-a-a-S model) and the way how platform teams make their platform available in a self-service model.
+Participants know Team Topologies as an organizational model for making teams work more effective. The specific focus is on understanding how APIs are necessary to make the Team Topologies model work. These areas are the consumption of existing services (X-a-a-S model) and the way how platform teams make their platform available in a self-service model.
 
 // end::EN[]

--- a/docs/08-api-governance/02-learning-goals.adoc
+++ b/docs/08-api-governance/02-learning-goals.adoc
@@ -38,10 +38,19 @@ Dies sind der Konsum von Diensten (X-a-a-S Modell) sowie das Anbieten von Dienst
 
 // tag::EN[]
 [[LG-8-1]]
-==== LG 8-1: TBD
+==== LG 8-1: Comparing Various Notions of Platform
 tbd.
 
 [[LG-8-2]]
-==== LG 8-2: TBD
+==== LG 8-2: Understanding API Guidelines
 tbd.
+
+[[LG-8-3]]
+==== LG 8-3: Establishing and Managing API Guidelines
+tbd.
+
+[[LG-8-4]]
+==== LG 8-4: Using APIs as Team Interfaces
+tbd.
+
 // end::EN[]

--- a/docs/08-api-governance/02-learning-goals.adoc
+++ b/docs/08-api-governance/02-learning-goals.adoc
@@ -38,7 +38,7 @@ Dies sind der Konsum von Diensten (X-a-a-S Modell) sowie das Anbieten von Dienst
 
 // tag::EN[]
 [[LG-8-1]]
-==== LG 8-1: Comparing Various Notions of Platform
+==== LG 8-1: Compare Various Notions of Platform
 
 Participants understand the various areas in which the notion of platforms are being used. They understand how these notions are different and how they complement each other.
 
@@ -49,17 +49,17 @@ Participants understand the various areas in which the notion of platforms are b
 Participants know how to differentiate between the mostly inward focus of an IDP and the both inwards and outwards directed focus of an API platform.
 
 [[LG-8-2]]
-==== LG 8-2: Understanding API Guidelines
+==== LG 8-2: Understand API Guidelines
 
 Participants understand the motivation for API guidelines. They understand the goals of creating harmonized practices for both API design and the implementation practices for APIs. Tools for supporting API guidelines such as linting are known and participants understand how they work.
 
 [[LG-8-3]]
-==== LG 8-3: Establishing and Managing API Guidelines
+==== LG 8-3: Establish and Manage API Guidelines
 
 Participants know some well-known examples of API guidelines by specific organizations. They also know good practices for managing and evolving API guidelines. Participants understand API guidelines as a living document that is managed in participatory ways which document actual practices (as opposed to describing an aspirational goal state).
 
 [[LG-8-4]]
-==== LG 8-4: Using APIs as Team Interfaces
+==== LG 8-4: Use APIs as Team Interfaces
 
 Participants know Team Topologies as an organizational model for making teams work more effective. The specific focus is on understanding how APIs are necessary to make the Team Topologies model work. These areas are the consumption of existing services (X-a-a-S model) and the way how platform teams make their platform available in a self-service model.
 

--- a/docs/08-api-governance/02-learning-goals.adoc
+++ b/docs/08-api-governance/02-learning-goals.adoc
@@ -39,18 +39,28 @@ Dies sind der Konsum von Diensten (X-a-a-S Modell) sowie das Anbieten von Dienst
 // tag::EN[]
 [[LG-8-1]]
 ==== LG 8-1: Comparing Various Notions of Platform
-tbd.
+
+Participants understand the various areas in which the notion of platforms are being used. They understand how these notions different and how they complement each other.
+
+* Internal developer platform (IDP)
+* API platform
+* Business platform
+
+Participants know how to differentiate between the mostly inward focus of an IDP and the both inwards and outwards directed focus of an API platform.
 
 [[LG-8-2]]
 ==== LG 8-2: Understanding API Guidelines
-tbd.
+
+Participants understand the motivation for API guidelines. They understand the goals of creating harmonized practices for both API design and the implementation practices for APIs. Tools for supporting API guidelines such as linting are know and participants understand how they work.
 
 [[LG-8-3]]
 ==== LG 8-3: Establishing and Managing API Guidelines
-tbd.
+
+Participants know some well-known examples of API guidelines by specific organizations. They also know good practices for managing and evolving API guidelines. Participants understand API guidelines as a living document that managed in participatory ways which document actual practices (as opposed to describing an aspirational goal state).
 
 [[LG-8-4]]
 ==== LG 8-4: Using APIs as Team Interfaces
-tbd.
+
+Participants know Team Topologies as an organizational model for making team work more effective. The specific focus is on understanding how APIs are necessary to make the Team Topologies model work. These areas are the consumption of existing services (X-a-a-S model) and the way how platform teams make their platform available in a self-service model.
 
 // end::EN[]


### PR DESCRIPTION
Here's a first version of the English translation of the current version. My plan is to use this as a good opportunity to publicize the curriculum a little better, and maybe iSAQB can help with that, @programming-wolf / @StefanZoerner ?

It also would be great to have this being incorporated in an updated RC better sooner than later. @sippsack, after this PR has been approved and merged, would you be so kind to do your tagging magic again? After that we should have a first complete version available at https://public.isaqb.org/curriculum-api/release-candidate/ which would be a good starting point for making a bit of noise about the RC.