### PR TITLE
Switching to sentence case for English learning goals

### DIFF
--- a/docs/01-why-apis/02-learning-goals.adoc
+++ b/docs/01-why-apis/02-learning-goals.adoc
@@ -21,13 +21,13 @@ Unterschiedliche Ansätze zur Systemintegration sind den Teilnehmer:innen bekann
 
 // tag::EN[]
 [[LG-1-1]]
-==== LG 1-1: Understand APIs in the Context of Software Development
+==== LG 1-1: Understand APIs in the context of software development
 
 Participants understand APIs in the context of programming, computer networks, distributed systems, and software architecture.
 They understand the development from local APIs to network-based APIs and the current API landscape in the overall context.
 
 [[LG-1-2]]
-==== LG 1-2: Compare different Styles and Concepts of Integration
+==== LG 1-2: Compare different styles and concepts of integration
 
 Different approaches for systems integration are known to participants and can be compared and contrasted, specifically:
 

--- a/docs/02-api-value/02-learning-goals.adoc
+++ b/docs/02-api-value/02-learning-goals.adoc
@@ -34,12 +34,12 @@ Teilnehmer:innen können APIs einordnen in das grössere Bild digitaler Transfor
 
 // tag::EN[]
 [[LG-2-1]]
-==== LG 2-1: Understand the "API Economy"
+==== LG 2-1: Understand the "API economy"
 
 Participants understand the broader concept of the "API Economy" and understand how their products and activities fit into it.
 
 [[LG-2-2]]
-==== LG 2-2: Know Various Ways of API Value Creation
+==== LG 2-2: Know various ways of API value creation
 
 Participants know and understand the various ways in which APIs can help with value creation. On the top level, the different ways can be categorized into three areas:
 
@@ -50,12 +50,12 @@ Participants know and understand the various ways in which APIs can help with va
 Participants understand the various options inside these categories and the relationships between them. They also understand how a comprehensive API strategy adds value for all of these categories.
 
 [[LG-2-3]]
-==== LG 2-3: Understand API Business Models
+==== LG 2-3: Understand API business models
 
 Participants have a detailed knowledge of the various business models for APIs and know a few specific examples. Starting from these different business models participants understand how to analyze existing business models and how they can be augmented with APIs.
 
 [[LG-2-4]]
-==== LG 2-4: Understand APIs and Digital Transformation
+==== LG 2-4: Understand APIs and digital transformation
 
 Participants know how to fit APIs into the bigger picture of digital transformation. APIs are identified as necessary (but not sufficient) aspect of digital transformation, and other necessary aspects are known as well:
 

--- a/docs/03-api-styles/02-learning-goals.adoc
+++ b/docs/03-api-styles/02-learning-goals.adoc
@@ -31,7 +31,7 @@ Teilnehmer:innen erwerben ein Verständnis für Kriterien, wann welche Stile/Tec
 
 // tag::EN[]
 [[LG-3-1]]
-==== LG 3-1: Understand Fundamental API Styles
+==== LG 3-1: Understand fundamental API styles
 
 The following API styles are understood by participants and their advantages and drawbacks can be compared:
 
@@ -42,7 +42,7 @@ The following API styles are understood by participants and their advantages and
 * Events & asynchronous communications
 
 [[LG-3-2]]
-==== LG 3-2: Understand Popular API Technologies and Associating Them With API Styles
+==== LG 3-2: Understand popular API technologies and associate them with API styles
 
 Participants are able to classify the most important API technologies and know which API style they are implementing, for example:
 
@@ -52,7 +52,7 @@ Participants are able to classify the most important API technologies and know w
 * GraphQL
 
 [[LG-3-3]]
-==== LG 3-3: Understand When to Use Which Style and Technology and the Consequences of That Choice
+==== LG 3-3: Understand when to use which style and technology and the consequences of that choice
 
 Participants gain knowledge of criteria when certain styles and technologies are a good or not-so-good fit, and which consequences the selection will have.
 

--- a/docs/04-api-design/02-learning-goals.adoc
+++ b/docs/04-api-design/02-learning-goals.adoc
@@ -46,12 +46,12 @@ Hierzu zählen u.a.:
 
 // tag::EN[]
 [[LG-4-1]]
-==== LG 4-1: Understand the Significance of API Design
+==== LG 4-1: Understand the significance of API design
 
 Participants understand why careful API design is important and which influence it has on usability, maintenance, evolution, and adoption. Participants understand that providers and consumers may evolve without centralized control and what the resulting challenges are.
 
 [[LG-4-2]]
-==== LG 4-2: Use the "outside-in" Approach for API Design
+==== LG 4-2: Use the "outside-in" approach for API design
 
 One of the most important goals of APIs is to efficiently connect consumers with the provider's interface.
 API design should be focused on the needs of the consumers.
@@ -59,13 +59,13 @@ It shouldn't be based on existing systems, existing use cases, or databases.
 Participants know and understand the approaches of API First and consumer-oriented API design.
 
 [[LG-4-3]]
-==== LG 4-3: Understand Openness and Extensibility as Important Aspects for API Evolution
+==== LG 4-3: Understand openness and extensibility as important aspects for API evolution
 
 Participants understand loose coupling, Postel's law, the concepts of forward and backward compatibility, and the importance of these concepts for the evolution of APIs.
 Participants also understand the consequences for API implementation in strong and statically typed languages.
 
 [[LG-4-4]]
-==== LG 4-4: Understand API Versioning
+==== LG 4-4: Understand API versioning
 
 Participants gain knowledge for various aspects of versioning and how these are applied during the lifecycle of an API product. The following concepts are known:
 
@@ -74,7 +74,7 @@ Participants gain knowledge for various aspects of versioning and how these are 
 * Different ways of version identification for APIs (for example, domain name, URI path, HTTP header, payload-based)
 
 [[LG-4-5]]
-==== LG 4-5: Know Good Practices for API Design
+==== LG 4-5: Know good practices for API design
 
 Participants learn about established and widely used aspects for API design and understand their advantages and challenges.
 These aspects include:

--- a/docs/05-api-description/02-learning-goals.adoc
+++ b/docs/05-api-description/02-learning-goals.adoc
@@ -38,17 +38,17 @@ OpenAPI ist spezialisiert auf HTTP APIs. Für andere API-Stile können alternati
 
 // tag::EN[]
 [[LG-5-1]]
-==== LG 5-1: Understand the Significance of API Descriptions
+==== LG 5-1: Understand the significance of API descriptions
 
 Participants understand the value of API descriptions and understand the various stakeholders. The problem of "API Drift" is known. Participants understand the relationship between design, implementation, versioning, description, and description versioning, and they understand how these concepts relate ideally and in real-world scenarios.
 
 [[LG-5-2]]
-==== LG 5-2: Understand OpenAPI as a Description Language for HTTP APIs
+==== LG 5-2: Understand OpenAPI as a description language for HTTP APIs
 
 Participants understand OpenAPI as a description language that is specialized for HTTP-based APIs. They understand the history of OpenAPI and how the various versions evolved. Participants understand how to use OpenAPI for code generation both on the provider side and on the consumer side, and that this practice has some risks. The overall structure of JSON and YAML is understood.
 
 [[LG-5-3]]
-==== LG 5-3: Understand OpenAPI's Structure
+==== LG 5-3: Understand OpenAPI's structure
 
 Participants understand the main elements of an OpenAPI description and how to use these for describing concrete APIs.
 
@@ -58,7 +58,7 @@ Participants understand the main elements of an OpenAPI description and how to u
 * Mechanisms such as Tags, Security, Components, and Webhooks
 
 [[LG-5-4]]
-==== LG 5-4: Understand Alternative Description Languages
+==== LG 5-4: Understand alternative description languages
 
 OpenAPI is specialized for HTTP-based APIs. For other API styles, it is possible to use alternative descriptions languages that have the same general goals. Participants know these alternative description languages and can associate them with API styles.
 

--- a/docs/06-api-lifecycle/02-learning-goals.adoc
+++ b/docs/06-api-lifecycle/02-learning-goals.adoc
@@ -25,21 +25,21 @@ Teilnehmer:innen können mit einigen dieser Tools praktisch arbeiten und versteh
 
 // tag::EN[]
 [[LG-6-1]]
-==== LG 6-1: Understand the API Lifecycle
+==== LG 6-1: Understand the API lifecycle
 
 Participants understand the various stages of the development cycle of an API product and the typical tasks that are performed throughout these stages.
 Participants understand the various stages of planning, requirements analysis, design, prototyping, development, testing, quality assurance, deployment, publication, operations, and maintenance, and how to improve an API product in an iterative way.
 Participants also know the different lifecycle stages of an API such as prototype, production, deprecation, and sunsetting.
 
 [[LG-6-2]]
-==== LG 6-2: Manage APIs as Products
+==== LG 6-2: Manage APIs as products
 
 APIs are often used in loosely coupled scenarios and for this reason it makes sense to manage them as products.
 Participants understand what it means to manage an API as a product.
 API product management starts with focus on a set of consumers, deals with questions of usability, includes feedback, and also handles questions of deprecation and how to provide alternatives.
 
 [[LG-6-3]]
-==== LG 6-3: Know API Lifecycle Tooling
+==== LG 6-3: Know API lifecycle tooling
 
 Participants know typical tools that are used throughout the API lifecycle. These tools support producers as well as consumers and include functionality such as linting, testing (e.g., contract testing), mocking, and operations (API gateways).
 Participants gain practical knowledge of some of these tools and understand how they fit into the bigger picture of API lifecycle tooling.

--- a/docs/07-api-security/02-learning-goals.adoc
+++ b/docs/07-api-security/02-learning-goals.adoc
@@ -22,13 +22,13 @@ Teilnehmer:innen kennen die OWASP API Security Top 10 und verstehen die darin be
 
 // tag::EN[]
 [[LG-7-1]]
-==== LG 7-1: Understand Communications Security Fundamentals
+==== LG 7-1: Understand communications security fundamentals
 
 Participants understand the foundations of communications security and are able to relate them to technologies such as TCP, HTTP, and TLS.
 Participants understand the relevance of secure communications, even in the case of internal interfaces.
 
 [[LG-7-2]]
-==== LG 7-2: Understand Security Technologies for APIs
+==== LG 7-2: Understand security technologies for APIs
 
 Participants understand HTTPS, HTTP authentication, OAuth, and OpenID Connect, how they relate and differ, and how these technologies help when it comes to securing APIs.
 

--- a/docs/08-api-governance/02-learning-goals.adoc
+++ b/docs/08-api-governance/02-learning-goals.adoc
@@ -38,7 +38,7 @@ Dies sind der Konsum von Diensten (X-a-a-S Modell) sowie das Anbieten von Dienst
 
 // tag::EN[]
 [[LG-8-1]]
-==== LG 8-1: Compare Various Notions of Platform
+==== LG 8-1: Compare various notions of platform
 
 Participants understand the various areas in which the notion of platforms are being used. They understand how these notions are different and how they complement each other.
 
@@ -49,17 +49,17 @@ Participants understand the various areas in which the notion of platforms are b
 Participants know how to differentiate between the mostly inward focus of an IDP and the both inwards and outwards directed focus of an API platform.
 
 [[LG-8-2]]
-==== LG 8-2: Understand API Guidelines
+==== LG 8-2: Understand API guidelines
 
 Participants understand the motivation for API guidelines. They understand the goals of creating harmonized practices for both API design and the implementation practices for APIs. Tools for supporting API guidelines such as linting are known and participants understand how they work.
 
 [[LG-8-3]]
-==== LG 8-3: Establish and Manage API Guidelines
+==== LG 8-3: Establish and manage API guidelines
 
 Participants know some examples of API guidelines by specific organizations. They also know good practices for managing and evolving API guidelines. Participants understand API guidelines as a living document that is managed in participatory ways which document actual practices.
 
 [[LG-8-4]]
-==== LG 8-4: Use APIs as Team Interfaces
+==== LG 8-4: Use APIs as team interfaces
 
 Participants know Team Topologies as an organizational model for making teams work more effective. The specific focus is on understanding how APIs are necessary to make the Team Topologies model work. These areas are the consumption of existing services (X-a-a-S model) and the way how platform teams make their platform available in a self-service model.
 


### PR DESCRIPTION
As suggested in #55. All English learning goals are using sentence case now.